### PR TITLE
fixed parsing on Windows where NewLine is two characters...

### DIFF
--- a/Scripts/env.cs
+++ b/Scripts/env.cs
@@ -28,7 +28,9 @@ namespace CandyCoded.env
         public static Dictionary<string, string> ParseEnvironmentFile(string contents)
         {
 
-            return contents.Trim().Split(new string[] { Environment.NewLine }, StringSplitOptions.None).Where(l =>
+            var lines = contents.Trim().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+
+            return lines.Where(l =>
                     !string.IsNullOrWhiteSpace(l) && !l.StartsWith("#") &&
                     l.IndexOf("=", StringComparison.Ordinal) != -1)
                 .ToDictionary(l => l.Substring(0, l.IndexOf("=", StringComparison.Ordinal)).Trim(),


### PR DESCRIPTION
Hi!

I noticed your parsing code throws an exception on Windows machine since the NewLine is a two-character string. This change should fix that issue!

Thank you!