### PR TITLE
Throw a warning if we find an existing runtime env.txt instead of an exception

### DIFF
--- a/Editor/Scripts/BuildTools.cs
+++ b/Editor/Scripts/BuildTools.cs
@@ -28,13 +28,6 @@ namespace CandyCoded.env.Editor
         public void OnPreprocessBuild(BuildReport report)
         {
 
-            if (File.Exists(env.runtimeFilePath))
-            {
-
-                throw new Exception($"{env.runtimeFilePath} already exists. Remove this file before continuing.");
-
-            }
-
             if (!Directory.Exists(env.resourcesDirPath))
             {
 
@@ -43,8 +36,14 @@ namespace CandyCoded.env.Editor
                 _resourcesDirCreated = true;
 
             }
-
-            if (File.Exists(env.editorFilePath))
+            
+            if (File.Exists(env.runtimeFilePath))
+            {   
+                
+                Debug.LogWarning($"{env.runtimeFilePath} already exists, using the existing file rather than copying current env.");
+                
+            }
+            else if (File.Exists(env.editorFilePath))
             {
 
                 FileUtil.CopyFileOrDirectory(env.editorFilePath, env.runtimeFilePath);

--- a/Editor/Scripts/BuildTools.cs
+++ b/Editor/Scripts/BuildTools.cs
@@ -5,6 +5,7 @@ using System.IO;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
+using UnityEngine;
 
 namespace CandyCoded.env.Editor
 {


### PR DESCRIPTION
Here's a suggestion for how to handle that case instead of throwing the exception. It does mean you might make a build with out of date env values. But odds are that the file is there because you just tried to make a build with those values and it failed, so using the file you had attempted to use seems fine.